### PR TITLE
Fix moveAxis and expose endstop pins

### DIFF
--- a/main/gcode.cpp
+++ b/main/gcode.cpp
@@ -12,6 +12,7 @@ extern int currentFeedrate;
 extern bool eStartSynced;
 extern const int fanPin;
 extern const int stepPinX, dirPinX, stepPinY, dirPinY, stepPinZ, dirPinZ, stepPinE, dirPinE;
+extern const int endstopX, endstopY, endstopZ;
 extern void playMario();
 extern void saveSettingsToEEPROM();
 extern void updateProgress();

--- a/main/main.ino
+++ b/main/main.ino
@@ -13,9 +13,6 @@ Bounce debouncer = Bounce();
 
 const int tempPin = A0;
 
-const int endstopX = A1;
-const int endstopY = A2;
-const int endstopZ = A3;
 
 float setTemp = 0.0;
 float Kp = 20, Ki = 1, Kd = 50;
@@ -280,7 +277,7 @@ void playMario() {
 }
 
 void moveAxis(int stepPin, int dirPin, long& pos, int target, int feedrate) {
-  int distance = target - (useAbsolute ? 0 : pos);
+  int distance = useAbsolute ? target - pos : target;
   int steps = abs(distance);
   int dir = (distance >= 0) ? HIGH : LOW;
   digitalWrite(dirPin, dir);
@@ -305,7 +302,7 @@ void moveAxis(int stepPin, int dirPin, long& pos, int target, int feedrate) {
     delayMicroseconds(delayPerStep);
   }
 
-  pos = useAbsolute ? target : pos + distance;
+  pos = useAbsolute ? target : pos + target;
 }
 
 

--- a/main/pins.cpp
+++ b/main/pins.cpp
@@ -1,4 +1,5 @@
 #include "pins.h"
+#include <Arduino.h>
 
 // CNC Shield 馬達腳位對應
 const int stepPinX = 2;
@@ -15,6 +16,10 @@ const int fanPin    = 10;
 const int heaterPin = 11;   // 例如 D11 可做 PWM 輸出
 const int buzzerPin = 12;   // 例如 D12 連接蜂鳴器
 const int buttonPin = 13;
+
+const int endstopX = A1;
+const int endstopY = A2;
+const int endstopZ = A3;
 
 // 軟體參數
 int eMaxSteps = 1000;

--- a/main/pins.h
+++ b/main/pins.h
@@ -11,6 +11,9 @@ extern const int fanPin;
 extern const int heaterPin;
 extern const int buzzerPin;
 extern const int buttonPin;
+extern const int endstopX;
+extern const int endstopY;
+extern const int endstopZ;
 
 // 軟體旗標與限制
 extern int eMaxSteps;


### PR DESCRIPTION
## Summary
- correct distance calculation in `moveAxis`
- update position handling for relative moves
- add endstop pin declarations/definitions
- include `<Arduino.h>` for pin macros

## Testing
- `g++ -c main/main.ino -o /tmp/main.o` *(fails: linker input file unused)*

------
https://chatgpt.com/codex/tasks/task_e_684151394c9c83269474872fc6d1b4f7