### PR TITLE
Add DEBUG_INPUT mode

### DIFF
--- a/main/gcode.cpp
+++ b/main/gcode.cpp
@@ -19,9 +19,38 @@ extern void playTune(int tune);
 extern void saveSettingsToEEPROM();
 extern void updateProgress();
 
-void processGcode() {
+#ifdef DEBUG_INPUT
+static const char *debugCommands[] = {
+    "G90",
+    "G1 X10 Y10 F800",
+    "M105",
+    "M106",
+    "M107",
+    "M400",
+    "M401 S1"
+};
+static const int debugCommandCount = sizeof(debugCommands) / sizeof(debugCommands[0]);
+static int debugIndex = 0;
+#endif
+
+static String getGcodeInput() {
+#ifdef DEBUG_INPUT
+    if (debugIndex < debugCommandCount) {
+        String cmd(debugCommands[debugIndex++]);
+        Serial.print(F("DBG> "));
+        Serial.println(cmd);
+        return cmd;
+    }
+#endif
     if (Serial.available()) {
-        String gcode = Serial.readStringUntil('\n');
+        return Serial.readStringUntil('\n');
+    }
+    return String();
+}
+
+void processGcode() {
+    String gcode = getGcodeInput();
+    if (gcode.length()) {
         gcode.trim();
 
         if (gcode.startsWith("G90")) {          // G90 - 進入絕對座標模式

--- a/main/main.ino
+++ b/main/main.ino
@@ -2,6 +2,8 @@
 // Optional test modes (disabled by default)
 //#define ENABLE_BUTTON_MENU_TEST
 //#define ENABLE_AXIS_CYCLE_TEST
+// Uncomment to feed predefined G-code without host software
+//#define DEBUG_INPUT
 
 #include <Wire.h>
 #include <LiquidCrystal_I2C.h>


### PR DESCRIPTION
## Summary
- add optional `DEBUG_INPUT` macro in `main.ino`
- support predefined G-code commands when `DEBUG_INPUT` is enabled

## Testing
- `arduino-cli compile --fqbn arduino:avr:uno main` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841745d62b08326861b7009eb9b4456