### PR TITLE
Improve axis cycle test LCD info

### DIFF
--- a/main/test_modes.cpp
+++ b/main/test_modes.cpp
@@ -42,6 +42,7 @@ void testMenuLoop() {
 // Axis order: X Y Z E
 static int currentAxis = 0;
 static bool moving = false;
+static const char axisChars[] = {'X', 'Y', 'Z', 'E'};
 
 void axisTestSetup() {
     showMessage("Axis Test", "Press Button");
@@ -53,10 +54,14 @@ void axisTestLoop() {
         if (moving) {
             moving = false;
             currentAxis = (currentAxis + 1) % 4;
-            showMessage("Switch Axis", "Press to Start");
+            char buf[17];
+            snprintf(buf, sizeof(buf), "Next: %c axis", axisChars[currentAxis]);
+            showMessage(buf, "Press to Start");
         } else {
             moving = true;
-            showMessage("Moving Axis", "Press to Stop");
+            char buf[17];
+            snprintf(buf, sizeof(buf), "Moving %c axis", axisChars[currentAxis]);
+            showMessage(buf, "Press to Stop");
         }
     }
 


### PR DESCRIPTION
## Summary
- show which axis is currently running in `ENABLE_AXIS_CYCLE_TEST`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847108ca520832699bd964332ccc648