### PR TITLE
Fix temp debug, progress, and double-click debounce

### DIFF
--- a/main/button.cpp
+++ b/main/button.cpp
@@ -48,8 +48,14 @@ bool longPressed(unsigned long ms) {
 
 bool doublePressed(unsigned long ms) {
     static unsigned long lastSingle = 0;
+    static const unsigned long debounceGap = 50; // ignore presses too close together
     if (consumeJust()) {
         unsigned long now = millis();
+        if (now - lastSingle <= debounceGap) {
+            // treat as bounce
+            lastSingle = now;
+            return false;
+        }
         if (now - lastSingle <= ms) {
             lastSingle = 0;
             return true;

--- a/main/state.cpp
+++ b/main/state.cpp
@@ -7,6 +7,7 @@ PrinterState printer;
 void resetPrinterState() {
     printer.setTemp = 0.0f;
     printer.currentTemp = 0.0f;
+    printer.rawTemp = 0;
     printer.tempError = false;
     printer.tempErrorNotified = false;
     printer.heatDoneBeeped = false;
@@ -38,6 +39,10 @@ void resetPrinterState() {
 
 void updateProgress() {
     if (printer.eTotal > 0) {
+        if (printer.eStart > printer.posE) {
+            // 若 E 軸回抽導致起點大於當前位置，歸零避免負值
+            printer.eStart = printer.posE;
+        }
         long delta = printer.posE - printer.eStart;
         if (delta > 0 && delta <= printer.eTotal) {
             printer.progress = (int)(delta * 100L / printer.eTotal);

--- a/main/state.h
+++ b/main/state.h
@@ -4,6 +4,7 @@ struct PrinterState {
     // 溫度控制
     float setTemp;
     float currentTemp;
+    int rawTemp; // last raw ADC value for debugging
     bool tempError;
     bool tempErrorNotified;
     bool heatDoneBeeped;

--- a/main/temp_control.cpp
+++ b/main/temp_control.cpp
@@ -3,11 +3,13 @@
 #include <Arduino.h>
 #include <math.h>
 #include <avr/wdt.h>
+#include "state.h"
 
 // Simple 100k thermistor using B=3950 equation
 // Returns temperature in Celsius
 float readThermistor(int pin) {
     int raw = analogRead(pin);
+    printer.rawTemp = raw; // keep raw reading for debugging
     float voltage = raw * 5.0f / 1023.0f;
     if (voltage <= 0.0f) {
         return -1000.0f; // invalid reading
@@ -19,7 +21,6 @@ float readThermistor(int pin) {
 }
 
 // External state variables defined in main.ino
-#include "state.h"
 extern unsigned long heatStableStart;
 extern const unsigned long stableHoldTime;
 


### PR DESCRIPTION
## Summary
- keep raw thermistor value for debugging
- reset extrusion start if retracted to avoid negative progress
- debounce double press detection

## Testing
- `bash setup_offline.sh` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68491939fd7483269fd2dc6f6e8edc9b