### PR TITLE
Improve serial reply consistency

### DIFF
--- a/main/gcode.h
+++ b/main/gcode.h
@@ -6,6 +6,7 @@
 
 void processGcode();
 void handleG1Axis(char axis, int stepPin, int dirPin, long& pos, String& gcode);
+void sendOk(const String &msg = "");
 #include "motion.h"
 
 // Steps per millimeter settings used for movement

--- a/main/motion.cpp
+++ b/main/motion.cpp
@@ -84,7 +84,7 @@ void homeAxis(int stepPin, int dirPin, int endstopPin, const char* label) {
         delayMicroseconds(800);
     }
     digitalWrite(motorEnablePin, LOW);
-    Serial.print(label);
-    Serial.println(" Homed");
+    extern void sendOk(const String &msg); // from gcode.cpp
+    sendOk(String(label) + " Homed");
 }
 #endif

--- a/main/test_modes.cpp
+++ b/main/test_modes.cpp
@@ -46,7 +46,7 @@ static const char axisChars[] = {'X', 'Y', 'Z', 'E'};
 
 void axisTestSetup() {
     showMessage("Axis Test", "Press Button");
-    Serial.println(F("Axis cycle test ready"));
+    sendOk(F("Axis cycle test ready"));
 }
 
 void axisTestLoop() {
@@ -58,13 +58,13 @@ void axisTestLoop() {
             char buf[17];
             snprintf(buf, sizeof(buf), "Next: %c axis", axisChars[currentAxis]);
             showMessage(buf, "Press to Start");
-            Serial.println(buf);
+            sendOk(String(buf));
         } else {
             moving = true;
             char buf[17];
             snprintf(buf, sizeof(buf), "Moving %c axis", axisChars[currentAxis]);
             showMessage(buf, "Press to Stop");
-            Serial.println(buf);
+            sendOk(String(buf));
         }
     }
 


### PR DESCRIPTION
## Summary
- unify serial responses with a new `sendOk` helper
- adjust gcode handling to use the unified format
- update homing and test modes to send standardized replies

## Testing
- `bash setup_offline.sh` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68491b6c017c8326bdca20e39d8b46c8