### PR TITLE
Fix missing externs for movement parameters

### DIFF
--- a/main/gcode.h
+++ b/main/gcode.h
@@ -15,5 +15,8 @@ extern float stepsPerMM_Y;
 extern float stepsPerMM_Z;
 extern float stepsPerMM_E;
 
+// Positioning mode flag (true = absolute mode)
+extern bool useAbsolute;
+
 
 #endif

--- a/main/motion.cpp
+++ b/main/motion.cpp
@@ -1,6 +1,7 @@
 #include "motion.h"
 #include "pins.h"
 #include "state.h"
+#include "gcode.h"
 #include <Arduino.h>
 
 // Prevent over-extrusion for the E axis (distance is in mm)


### PR DESCRIPTION
## Summary
- expose `useAbsolute` in gcode.h
- include gcode.h in motion.cpp so that global settings are visible

## Testing
- `bash setup_offline.sh` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6849a2e0342883269b728cfe50131a88