### PR TITLE
Fix PID divide by zero

### DIFF
--- a/main/temp_control.cpp
+++ b/main/temp_control.cpp
@@ -84,7 +84,8 @@ void readTemperature() {
 void controlHeater() {
     if (printer.setTemp > 0.0) {
         unsigned long now = millis();
-        float elapsed = (now - printer.lastTime) / 1000.0;
+        float elapsed = (now - printer.lastTime) / 1000.0f;
+        elapsed = max(elapsed, 0.001f); // avoid divide by zero
         printer.lastTime = now;
 
         float error = printer.setTemp - printer.currentTemp;


### PR DESCRIPTION
## Summary
- avoid PID divide by zero when `elapsed` is zero

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_684a71bdb4688326aea71f4a70035c3c