### PR TITLE
Fix LCD float formatting

### DIFF
--- a/main/gcode.cpp
+++ b/main/gcode.cpp
@@ -5,6 +5,7 @@
 #include <LiquidCrystal_I2C.h>
 #include <avr/wdt.h>
 #include <string.h>
+#include <stdlib.h>
 
 // Unified serial response helper
 void sendOk(const String &msg = "") {
@@ -34,9 +35,18 @@ static void displayM503LCD() {
     for (int t = 5; t > 0; --t) {
         char line1[17];
         char line2[17];
-        snprintf(line1, sizeof(line1), "P%.0f I%.0f D%.0f %d", printer.Kp, printer.Ki, printer.Kd, t);
-        snprintf(line2, sizeof(line2), "X%.0f Y%.0f Z%.0f E%.0f", stepsPerMM_X,
-                 stepsPerMM_Y, stepsPerMM_Z, stepsPerMM_E);
+        char kp[8], ki[8], kd[8];
+        dtostrf(printer.Kp, 1, 0, kp);
+        dtostrf(printer.Ki, 1, 0, ki);
+        dtostrf(printer.Kd, 1, 0, kd);
+        snprintf(line1, sizeof(line1), "P%s I%s D%s %d", kp, ki, kd, t);
+
+        char sx[8], sy[8], sz[8], se[8];
+        dtostrf(stepsPerMM_X, 1, 0, sx);
+        dtostrf(stepsPerMM_Y, 1, 0, sy);
+        dtostrf(stepsPerMM_Z, 1, 0, sz);
+        dtostrf(stepsPerMM_E, 1, 0, se);
+        snprintf(line2, sizeof(line2), "X%s Y%s Z%s E%s", sx, sy, sz, se);
         showMessage(line1, line2);
         delay(1000);
         wdt_reset();

--- a/main/main.ino
+++ b/main/main.ino
@@ -10,6 +10,7 @@
 #include <math.h>
 #include <avr/wdt.h>
 #include <string.h>
+#include <stdlib.h>
 #include "button.h"
 #include <EEPROM.h>
 #include "pins.h"
@@ -108,8 +109,12 @@ void showMessage(const char* line1, const char* line2) {
 }
 
 void displayTempScreen() {
+    char cur[8];
+    char set[8];
+    dtostrf(printer.currentTemp, 4, 1, cur);
+    dtostrf(printer.setTemp, 3, 0, set);
     char buf[17];
-    snprintf(buf, sizeof(buf), "T:%.1f%cC Set:%.0f", printer.currentTemp, 223, printer.setTemp);
+    snprintf(buf, sizeof(buf), "T:%s%cC Set:%s", cur, 223, set);
     showMessage(buf, "");
 }
 


### PR DESCRIPTION
## Summary
- ensure `dtostrf` handles floats for LCD output
- display PID/steps info without `%f`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856d02268d88326a6897764020b3264