### PR TITLE
Avoid button conflict during axis cycle test

### DIFF
--- a/main/motion.cpp
+++ b/main/motion.cpp
@@ -49,7 +49,9 @@ static void moveWithAccel(int stepPin, long steps, long minDelay) {
         unsigned long now = millis();
         if (now - lastPoll >= 50) {
             lastPoll = now;
+#ifndef ENABLE_AXIS_CYCLE_TEST
             checkButton();
+#endif
             wdt_reset();
         }
 


### PR DESCRIPTION
## Summary
- skip button polling inside `moveWithAccel` when the axis cycle test is active

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856d817d828832691e2a06e8d6f05d0