### PR TITLE
Allow extruder move when eTotal unset

### DIFF
--- a/main/gcode.cpp
+++ b/main/gcode.cpp
@@ -255,9 +255,7 @@ void handleG1Axis(char axis, int stepPin, int dirPin, long& pos, String& gcode) 
         // E 軸同步判斷與進度更新
         if (&pos == &printer.posE) {
             if (printer.eTotal == -1) {
-                Serial.println(F("error: eTotal not set"));
-                sendOk();
-                return;
+                Serial.println(F("warning: eTotal not set"));
             }
             if (!printer.eStartSynced) {
                 printer.eStart = printer.posE;

--- a/main/motion.cpp
+++ b/main/motion.cpp
@@ -8,11 +8,6 @@
 // Access button handling from main program
 extern void checkButton();
 
-// Determine whether the axis should be physically moved
-static bool isPhysicalAxis(char axis) {
-    // When eTotal is negative we are in "virtual extrusion" mode
-    return !(axis == 'E' && printer.eTotal < 0);
-}
 
 // Calculate step count and apply extrusion limits
 static long calculateSteps(char axis, long currentPos, int &distance, float spm) {
@@ -83,17 +78,15 @@ void moveAxis(int stepPin, int dirPin, long& pos, int target, int feedrate, char
         return;
     }
 
-    if (isPhysicalAxis(axis)) {
-        digitalWrite(motorEnablePin, LOW);
-        setMotorDirection(dirPin, distance);
+    digitalWrite(motorEnablePin, LOW);
+    setMotorDirection(dirPin, distance);
 
-        long minDelay = (long)(60000000.0 / (feedrate * spm));
-        minDelay = max(50L, minDelay);  // minimum safety
+    long minDelay = (long)(60000000.0 / (feedrate * spm));
+    minDelay = max(50L, minDelay);  // minimum safety
 
-        moveWithAccel(stepPin, steps, minDelay);
+    moveWithAccel(stepPin, steps, minDelay);
 
-        digitalWrite(motorEnablePin, HIGH);
-    }
+    digitalWrite(motorEnablePin, HIGH);
 
     // Update position once using final travel distance
     pos += distance;


### PR DESCRIPTION
## Summary
- allow G1 E commands when progress is not set
- always treat E axis as physical so users can manually move it
- remove now-unnecessary `isPhysicalAxis` helper

## Testing
- `g++ --version`
- `arduino-cli version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f096266088326bf598bb6c5b9b68a