### PR TITLE
Fix homing by polling endstops

### DIFF
--- a/main/gcode.cpp
+++ b/main/gcode.cpp
@@ -2,7 +2,6 @@
 #include "gcode.h"
 #include "tunes.h"
 #include "state.h"
-#include "interrupts.h"
 #include <LiquidCrystal_I2C.h>
 #include <avr/wdt.h>
 #include <string.h>
@@ -22,7 +21,7 @@ void sendOk(const String &msg = "") {
 extern bool useAbsolute;
 extern int currentFeedrate;
 extern const int stepPinX, dirPinX, stepPinY, dirPinY, stepPinZ, dirPinZ, stepPinE, dirPinE;
-extern volatile bool endstopXTriggered, endstopYTriggered, endstopZTriggered;
+extern const int endstopX, endstopY, endstopZ;
 extern void playTune(int tune);
 extern void saveSettingsToEEPROM();
 extern void updateProgress();
@@ -232,9 +231,9 @@ void processGcode() {
                 handleG1Axis('E', stepPinE, dirPinE, printer.posE, gcode);
         } else if (gcode.startsWith("G28")) {   // G28 - 執行回原點（需開啟 ENABLE_HOMING）
 #ifdef ENABLE_HOMING
-            homeAxis(stepPinX, dirPinX, endstopXTriggered, "X");
-            homeAxis(stepPinY, dirPinY, endstopYTriggered, "Y");
-            homeAxis(stepPinZ, dirPinZ, endstopZTriggered, "Z");
+            homeAxis(stepPinX, dirPinX, endstopX, "X");
+            homeAxis(stepPinY, dirPinY, endstopY, "Y");
+            homeAxis(stepPinZ, dirPinZ, endstopZ, "Z");
 #else
             sendOk(F("Homing disabled"));
 #endif

--- a/main/motion.cpp
+++ b/main/motion.cpp
@@ -93,18 +93,16 @@ void moveAxis(int stepPin, int dirPin, long& pos, int target, int feedrate, char
 }
 
 #ifdef ENABLE_HOMING
-void homeAxis(int stepPin, int dirPin, volatile bool &triggered, const char* label) {
-    triggered = false;
+void homeAxis(int stepPin, int dirPin, int endstopPin, const char* label) {
     digitalWrite(motorEnablePin, LOW);
     digitalWrite(dirPin, LOW);
-    while (!triggered) {
+    while (digitalRead(endstopPin) == HIGH) {
         digitalWrite(stepPin, HIGH);
         delayMicroseconds(800);
         digitalWrite(stepPin, LOW);
         delayMicroseconds(800);
     }
     digitalWrite(motorEnablePin, HIGH);
-    triggered = false;
     extern void sendOk(const String &msg); // from gcode.cpp
     sendOk(String(label) + " Homed");
 }

--- a/main/motion.h
+++ b/main/motion.h
@@ -4,5 +4,5 @@
 void moveAxis(int stepPin, int dirPin, long& pos, int target, int feedrate, char axis);
 
 #ifdef ENABLE_HOMING
-void homeAxis(int stepPin, int dirPin, volatile bool &triggered, const char* label);
+void homeAxis(int stepPin, int dirPin, int endstopPin, const char* label);
 #endif


### PR DESCRIPTION
## Summary
- restore endstop pins in gcode and homing routine
- poll endstop pins with `digitalRead()`

## Testing
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_687f44a170cc8326bbb610b074468eec