### PR TITLE
Fix limit switch polling

### DIFF
--- a/main/gcode.cpp
+++ b/main/gcode.cpp
@@ -2,7 +2,6 @@
 #include "gcode.h"
 #include "tunes.h"
 #include "state.h"
-#include "interrupts.h"
 #include <LiquidCrystal_I2C.h>
 #include <avr/wdt.h>
 #include <string.h>
@@ -22,7 +21,7 @@ void sendOk(const String &msg = "") {
 extern bool useAbsolute;
 extern int currentFeedrate;
 extern const int stepPinX, dirPinX, stepPinY, dirPinY, stepPinZ, dirPinZ, stepPinE, dirPinE;
-extern volatile bool endstopXTriggered, endstopYTriggered, endstopZTriggered;
+extern const int endstopX, endstopY, endstopZ;
 extern void playTune(int tune);
 extern void saveSettingsToEEPROM();
 extern void updateProgress();
@@ -231,9 +230,9 @@ void processGcode() {
                 handleG1Axis('Z', stepPinZ, dirPinZ, printer.posZ, gcode);
                 handleG1Axis('E', stepPinE, dirPinE, printer.posE, gcode);
         } else if (gcode.startsWith("G28")) {   // G28 - 執行回原點
-            homeAxis(stepPinX, dirPinX, endstopXTriggered, "X");
-            homeAxis(stepPinY, dirPinY, endstopYTriggered, "Y");
-            homeAxis(stepPinZ, dirPinZ, endstopZTriggered, "Z");
+            homeAxis(stepPinX, dirPinX, endstopX, "X");
+            homeAxis(stepPinY, dirPinY, endstopY, "Y");
+            homeAxis(stepPinZ, dirPinZ, endstopZ, "Z");
         } else {  // 其他未知指令
             Serial.print(F("error: Unknown command "));
             Serial.println(gcode);

--- a/main/motion.cpp
+++ b/main/motion.cpp
@@ -90,18 +90,16 @@ void moveAxis(int stepPin, int dirPin, long& pos, int target, int feedrate, char
     pos += distance;
 }
 
-void homeAxis(int stepPin, int dirPin, volatile bool &triggered, const char* label) {
-    triggered = false;
+void homeAxis(int stepPin, int dirPin, int endstopPin, const char* label) {
     digitalWrite(motorEnablePin, LOW);
     digitalWrite(dirPin, LOW);
-    while (!triggered) {
+    while (digitalRead(endstopPin) == HIGH) {
         digitalWrite(stepPin, HIGH);
         delayMicroseconds(800);
         digitalWrite(stepPin, LOW);
         delayMicroseconds(800);
     }
     digitalWrite(motorEnablePin, HIGH);
-    triggered = false;
     extern void sendOk(const String &msg); // from gcode.cpp
     sendOk(String(label) + " Homed");
 }

--- a/main/motion.h
+++ b/main/motion.h
@@ -3,4 +3,4 @@
 
 void moveAxis(int stepPin, int dirPin, long& pos, int target, int feedrate, char axis);
 
-void homeAxis(int stepPin, int dirPin, volatile bool &triggered, const char* label);
+void homeAxis(int stepPin, int dirPin, int endstopPin, const char* label);


### PR DESCRIPTION
## Summary
- remove unused endstop flags and polling
- read limit switch pins directly when homing

## Testing
- `ls -R | grep -E '(Makefile|test|ci|build)' -i`
- `g++ -c main/*.cpp` *(fails: Arduino headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_687f4a3ddefc83269bb53f17174bab78