### PR TITLE
Fix buzzer always on

### DIFF
--- a/main/gcode.cpp
+++ b/main/gcode.cpp
@@ -197,9 +197,7 @@ void processGcode() {
             String pidMsg = String("Kp:") + printer.Kp + " Ki:" + printer.Ki + " Kd:" + printer.Kd + " Kr:" + printer.Kr;
             sendOk(pidMsg);
         } else if (gcode.startsWith("M400")) {  // M400 - 播放選定音樂，列印完成提示
-#ifdef ENABLE_BUZZER
             playTune(printer.currentTune);
-#endif
             sendOk(F("Print Complete"));
         } else if (gcode.startsWith("M401")) {  // M401 Sn - 設定列印完成音樂
             int sIndex = gcode.indexOf('S');

--- a/main/main.ino
+++ b/main/main.ino
@@ -381,9 +381,7 @@ void setup() {
     initButton(buttonPin);
 
     pinMode(heaterPin, OUTPUT);
-#ifdef ENABLE_BUZZER
     pinMode(buzzerPin, OUTPUT);
-#endif
     pinMode(motorEnablePin, OUTPUT);
     
     // Configure stepper driver pins

--- a/main/pins.cpp
+++ b/main/pins.cpp
@@ -15,11 +15,8 @@ const int dirPinE  = 13;
 const int heaterPin = 10;//Y- 3,5,6,9,10,11可做 PWM 輸出
 // Thermistor connected to analog pin A3
 const int tempPin   = A3;//Cooler
-#ifndef BUZZER_PIN
-#define BUZZER_PIN 9
-#endif
-// Buzzer pin defaults to D9 but can be overridden with BUZZER_PIN
-const int buzzerPin = BUZZER_PIN;
+// Buzzer pin fixed to D9
+const int buzzerPin = 9;
 // Motor enable uses D8
 const int motorEnablePin = 8;
 const int buttonPin = 11;//Z-

--- a/main/pins.h
+++ b/main/pins.h
@@ -10,7 +10,7 @@ extern const int stepPinE, dirPinE;
 extern const int heaterPin;
 extern const int tempPin;
 
-// Buzzer pin defaults to D9, override with -DBUZZER_PIN=<pin>
+// Buzzer pin fixed to D9
 extern const int buzzerPin;
 extern const int motorEnablePin;
 extern const int buttonPin;

--- a/main/temp_control.cpp
+++ b/main/temp_control.cpp
@@ -43,19 +43,15 @@ extern const unsigned long stableHoldTime;
 // Pins from pins.h
 extern const int heaterPin;
 extern const int tempPin;
-#ifdef ENABLE_BUZZER
 extern const int buzzerPin;
-#endif
 
 void beepErrorAlert() {
-#ifdef ENABLE_BUZZER
     for (int i = 0; i < 5; i++) {
         tone(buzzerPin, 1000, 150);
         delay(200);
         wdt_reset();
     }
     noTone(buzzerPin);
-#endif
 }
 
 void readTemperature() {
@@ -112,9 +108,7 @@ void readTemperature() {
     }
 
     if (printer.tempError && !printer.tempErrorNotified) {
-#ifdef ENABLE_BUZZER
         beepErrorAlert();
-#endif
         printer.tempErrorNotified = true;
     }
 }
@@ -206,9 +200,7 @@ void controlHeater() {
                 heatStableStart = now;
             }
             if (!printer.heatDoneBeeped && (now - heatStableStart >= stableHoldTime)) {
-#ifdef ENABLE_BUZZER
                 playTune(TUNE_HEAT_DONE);
-#endif
                 printer.heatDoneBeeped = true;
             }
         } else {

--- a/main/tunes.cpp
+++ b/main/tunes.cpp
@@ -26,7 +26,6 @@ static const int tetrisDur[]   = {150,150,150,150,150,150,150,150,150,150,150,15
 static const int heatNotes[] = {880, 988, 1047};
 static const int heatDur[]   = {150, 150, 300};
 
-#ifdef ENABLE_BUZZER
 void playTune(int tune) {
     const int *notes = marioNotes;
     const int *durs = marioDur;
@@ -84,4 +83,3 @@ void playTune(int tune) {
     wdt_reset();
     lcd.clear();
 }
-#endif

--- a/main/tunes.h
+++ b/main/tunes.h
@@ -1,8 +1,6 @@
 #pragma once
 #include <Arduino.h>
 
-// Uncomment to enable buzzer features
-// #define ENABLE_BUZZER
 
 // Enumeration of available completion tunes
 enum TuneType {
@@ -14,8 +12,4 @@ enum TuneType {
     TUNE_COUNT
 };
 
-#ifdef ENABLE_BUZZER
 void playTune(int tune);
-#else
-inline void playTune(int tune) {}
-#endif


### PR DESCRIPTION
## Summary
- remove `ENABLE_BUZZER` conditionals so the buzzer is always active
- keep buzzer pin fixed to D9 via `const int buzzerPin = 9`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6881c4d7e1288326a144120912349c20