### PR TITLE
Add separate heater simulation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,9 +207,9 @@ M400
 
 ---
 
-## DEBUG_INPUT 模式
+## 模擬模式
 
-在 `main.ino` 取消註解 `#define DEBUG_INPUT` 後，韌體會自動執行內建 G-code，模擬加熱與整個列印流程。
+在 `main.ino` 取消註解 `#define SIMULATE_GCODE_INPUT` 後，韌體會自動執行內建 G-code，並模擬加熱流程。若僅需讓切片軟體忽略加熱等待，可啟用 `#define SIMULATE_HEATER`。
 溫度僅以程式線性遞增，不會驅動加熱 MOSFET；馬達仍依序移動，包含擠出軸。
 啟用此模式前請將耗材退出或暫時不裝料，以免空轉擠出。
 若已使用 `M290` 設定總進度，每次 E 軸指令後會在序列埠輸出目前百分比；

--- a/main/gcode.cpp
+++ b/main/gcode.cpp
@@ -56,7 +56,7 @@ static void displayM503LCD() {
     memset(lastDisplayContent, 0, sizeof(lastDisplayContent));
 }
 
-#ifdef DEBUG_INPUT
+#ifdef SIMULATE_GCODE_INPUT
 static const char *debugCommands[] = {
     "M104 S200",
     "M290 E100",
@@ -75,7 +75,7 @@ static int debugIndex = 0;
 #endif
 
 static String getGcodeInput() {
-#ifdef DEBUG_INPUT
+#ifdef SIMULATE_GCODE_INPUT
     if (debugIndex < debugCommandCount) {
         String cmd(debugCommands[debugIndex++]);
         Serial.print(F("DBG> "));

--- a/main/main.ino
+++ b/main/main.ino
@@ -1,7 +1,9 @@
 // Uncomment to feed predefined G-code without host software
 // When enabled the heater output is mocked but all motors, including
 // the extruder, will move according to the test G-code.
-//#define DEBUG_INPUT
+//#define SIMULATE_GCODE_INPUT
+// Uncomment to bypass real heater control and simulate temperature readings
+//#define SIMULATE_HEATER
 
 #include <Wire.h>
 #include <LiquidCrystal_I2C.h>

--- a/main/temp_control.cpp
+++ b/main/temp_control.cpp
@@ -9,7 +9,7 @@
 // Simple 100k thermistor using B=3950 equation
 // Returns temperature in Celsius
 float readThermistor(int pin) {
-#ifdef DEBUG_INPUT
+#if defined(SIMULATE_HEATER) || defined(SIMULATE_GCODE_INPUT)
     // In debug mode simulate a simple linear temperature ramp
     static float simTemp = 25.0f;
     if (printer.setTemp > simTemp) {
@@ -101,7 +101,7 @@ void readTemperature() {
         printer.tempError = true;
         printer.tempErrorNotified = false;
         printer.setTemp = 0;
-        #ifndef DEBUG_INPUT
+        #if !(defined(SIMULATE_HEATER) || defined(SIMULATE_GCODE_INPUT))
         analogWrite(heaterPin, 0);
         #endif
         printer.heaterOn = false;
@@ -127,7 +127,7 @@ void controlHeater() {
         if (printer.currentTemp > printer.setTemp + 15.0f) {
             overshootCount++;
             if (overshootCount >= 3) {
-#ifndef DEBUG_INPUT
+#if !(defined(SIMULATE_HEATER) || defined(SIMULATE_GCODE_INPUT))
                 analogWrite(heaterPin, 0);
 #endif
                 printer.setTemp = 0;
@@ -141,7 +141,7 @@ void controlHeater() {
         }
 
         if (heatStart > 0 && now - heatStart > 180000) {
-#ifndef DEBUG_INPUT
+#if !(defined(SIMULATE_HEATER) || defined(SIMULATE_GCODE_INPUT))
             analogWrite(heaterPin, 0);
 #endif
             printer.setTemp = 0;
@@ -189,7 +189,7 @@ void controlHeater() {
         printer.lastOutput = scaledOutput;  // 儲存實際PWM輸出
         printer.pwmValue = scaledOutput;
 
-#ifndef DEBUG_INPUT
+#if !(defined(SIMULATE_HEATER) || defined(SIMULATE_GCODE_INPUT))
         analogWrite(heaterPin, (int)scaledOutput);
 #endif
         printer.heaterOn = scaledOutput > 0;
@@ -207,7 +207,7 @@ void controlHeater() {
             heatStableStart = 0;
         }
     } else {
-#ifndef DEBUG_INPUT
+#if !(defined(SIMULATE_HEATER) || defined(SIMULATE_GCODE_INPUT))
         analogWrite(heaterPin, 0);
 #endif
         printer.heaterOn = false;


### PR DESCRIPTION
## Summary
- rename `DEBUG_INPUT` to `SIMULATE_GCODE_INPUT`
- add new `SIMULATE_HEATER` option for bypassing heater control
- update documentation for new options

## Testing
- `arduino-cli version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881cbc923108326a64cac9145f4cfb7