### PR TITLE
Shorten Serial error strings

### DIFF
--- a/main/gcode.cpp
+++ b/main/gcode.cpp
@@ -318,7 +318,7 @@ void processGcode() {
             printer.posZ = 0;
             sendOk(F("G28 Done"));
         } else {  // 其他未知指令
-            Serial.print(F("error: Unknown command "));
+            Serial.print(F("ERR: Unknown cmd "));
             Serial.println(gcode);
         }
     }

--- a/main/motion.cpp
+++ b/main/motion.cpp
@@ -195,7 +195,7 @@ void moveAxes(long targetX, long targetY, long targetZ, long targetE, int feedra
 
     if (distE != 0) {
         if (printer.eTotal == -1) {
-            Serial.println(F("warning: eTotal not set"));
+            Serial.println(F("WARN: eTotal unset"));
         }
         if (!printer.eStartSynced) {
             printer.eStart = printer.posE;

--- a/main/temp_control.cpp
+++ b/main/temp_control.cpp
@@ -132,7 +132,7 @@ void controlHeater() {
 #endif
                 printer.setTemp = 0;
                 printer.heaterOn = false;
-                Serial.println("!! ERROR: Overshoot too high, heater disabled.");
+                Serial.println(F("ERROR: Overshoot"));
                 heatStart = 0;
                 return;
             }
@@ -147,7 +147,7 @@ void controlHeater() {
             printer.setTemp = 0;
             printer.heaterOn = false;
             heatStart = 0;
-            Serial.println("!! ERROR: Heating timeout, heater disabled.");
+            Serial.println(F("ERROR: Heat timeout"));
             return;
         }
 


### PR DESCRIPTION
## Summary
- trim overshoot and timeout error strings
- shorten warning text
- shorten message for unknown G-code command

## Testing
- `git diff --color --stat`


------
https://chatgpt.com/codex/tasks/task_e_6881deaf7fac8326993843311ffe6de6