### PR TITLE
Add compile-time tune selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,11 @@
 
 | `M301 Pn In Dn`   | 設定 PID 控溫參數並儲存至 EEPROM                | `M301 P20.0 I1.5 D60.0`         |
 | `M400`            | 播放設定的音樂提示列印完成                      | `M400`                          |
-| `M401 Sn`         | 選擇列印完成音樂（0~3）                         | `M401 S1`                       |
 | `M92 Xn Yn Zn En` | 設定各軸每毫米步數（steps/mm）                  | `M92 X25 Y25 Z25 E25`           |
 | `M290 En`         | 設定列印進度總量（E 軸長度）                    | `M290 E1200`                    |
 | `M500`            | 將目前設定存入 EEPROM                           | `M500`                          |
 | `M503`            | 列印目前 PID 與 steps/mm 等參數                 | `M503`                          |
 
-可用音樂編號：0=Mario、1=Canon、2=StarWars、3=Tetris、4=Heat
 
 ---
 
@@ -232,6 +230,19 @@ M104 S200
 M105
 M400
 ```
+
+### 音樂選擇
+
+預設只會編譯一首完成提示音，可在 `tunes.h` 定義下列其中一個旗標：
+
+```cpp
+#define USE_TUNE_MARIO      // 預設
+//#define USE_TUNE_CANON
+//#define USE_TUNE_STAR_WARS
+//#define USE_TUNE_TETRIS
+```
+
+同時定義兩個以上會在編譯時產生錯誤。
 
 ### 停用音效
 

--- a/main/gcode.cpp
+++ b/main/gcode.cpp
@@ -68,7 +68,7 @@ static const char *debugCommands[] = {
     "G1 E100 F600",
     "M105",
     "M400",
-    "M401 S1"
+    // "M401 S1" // tune selection removed
 };
 static const int debugCommandCount = sizeof(debugCommands) / sizeof(debugCommands[0]);
 static int debugIndex = 0;
@@ -192,19 +192,6 @@ void processGcode() {
             playTune(printer.currentTune);
 #endif
             sendOk(F("Print Complete"));
-        } else if (gcode.startsWith("M401")) {  // M401 Sn - 設定列印完成音樂
-            int sIndex = gcode.indexOf('S');
-            if (sIndex != -1) {
-                int val = gcode.substring(sIndex + 1).toInt();
-                if (val >= 0 && val < TUNE_COUNT) {
-                    printer.currentTune = val;
-                    sendOk(String("Tune set to ") + val);
-                } else {
-                    sendOk(F("Invalid tune"));
-                }
-            } else {
-                sendOk(String("Current tune: ") + printer.currentTune);
-            }
         } else if (gcode.startsWith("M92")) {   // M92 - 設定各軸 steps/mm
             int idx;
             float val;

--- a/main/state.cpp
+++ b/main/state.cpp
@@ -35,7 +35,7 @@ void resetPrinterState() {
     printer.previousError = 0.0f;
     printer.lastTime = millis();
 
-    printer.currentTune = TUNE_MARIO; // default tune defined in tunes.h
+    printer.currentTune = DEFAULT_TUNE; // default tune selected in tunes.h
 
     printer.paused = false;
 }

--- a/main/tunes.cpp
+++ b/main/tunes.cpp
@@ -4,64 +4,44 @@
 #include <LiquidCrystal_I2C.h>
 #include <avr/wdt.h>
 
-extern LiquidCrystal_I2C lcd;
-
 #ifndef NO_TUNES
 
-// Mario tune
-static const int marioNotes[] = {262, 262, 0, 262, 0, 196, 262, 0, 0, 0, 294, 0, 330};
-static const int marioDur[]   = {200, 200, 100, 200, 100, 400, 400, 100, 100, 100, 400, 100, 600};
+extern LiquidCrystal_I2C lcd;
 
-// Pachelbel's Canon simple snippet
-static const int canonNotes[] = {392, 440, 494, 523, 587, 523, 494, 440, 392};
-static const int canonDur[]   = {250, 250, 250, 250, 250, 250, 250, 250, 500};
-
-// Star Wars theme snippet
-static const int starNotes[]  = {440, 440, 440, 349, 523, 440, 349, 523, 440};
-static const int starDur[]    = {300, 300, 300, 200, 600, 300, 200, 600, 800};
-
-// Tetris theme snippet
-static const int tetrisNotes[] = {659,494,523,587,523,494,440,440,523,659,587,523,494,523,587,659};
-static const int tetrisDur[]   = {150,150,150,150,150,150,150,150,150,150,150,150,150,150,150,150};
+// Completion tune selected at compile time
+#if defined(USE_TUNE_MARIO)
+static const int compNotes[] = {262, 262, 0, 262, 0, 196, 262, 0, 0, 0, 294, 0, 330};
+static const int compDur[]   = {200, 200, 100, 200, 100, 400, 400, 100, 100, 100, 400, 100, 600};
+#define COMP_LABEL "Mario"
+#elif defined(USE_TUNE_CANON)
+static const int compNotes[] = {392, 440, 494, 523, 587, 523, 494, 440, 392};
+static const int compDur[]   = {250, 250, 250, 250, 250, 250, 250, 250, 500};
+#define COMP_LABEL "Canon"
+#elif defined(USE_TUNE_STAR_WARS)
+static const int compNotes[]  = {440, 440, 440, 349, 523, 440, 349, 523, 440};
+static const int compDur[]    = {300, 300, 300, 200, 600, 300, 200, 600, 800};
+#define COMP_LABEL "StarWars"
+#elif defined(USE_TUNE_TETRIS)
+static const int compNotes[] = {659,494,523,587,523,494,440,440,523,659,587,523,494,523,587,659};
+static const int compDur[]   = {150,150,150,150,150,150,150,150,150,150,150,150,150,150,150,150};
+#define COMP_LABEL "Tetris"
+#endif
 
 // Simple tune for temperature reached
 static const int heatNotes[] = {880, 988, 1047};
 static const int heatDur[]   = {150, 150, 300};
 
 void playTune(int tune) {
-    const int *notes = marioNotes;
-    const int *durs = marioDur;
-    int length = sizeof(marioNotes)/sizeof(int);
-    const char *label = "Mario";
+    const int *notes = compNotes;
+    const int *durs = compDur;
+    int length = sizeof(compNotes)/sizeof(int);
+    const char *label = COMP_LABEL;
 
-    switch (tune) {
-        case TUNE_CANON:
-            notes = canonNotes;
-            durs = canonDur;
-            length = sizeof(canonNotes)/sizeof(int);
-            label = "Canon";
-            break;
-        case TUNE_STAR_WARS:
-            notes = starNotes;
-            durs = starDur;
-            length = sizeof(starNotes)/sizeof(int);
-            label = "StarWars";
-            break;
-        case TUNE_TETRIS:
-            notes = tetrisNotes;
-            durs = tetrisDur;
-            length = sizeof(tetrisNotes)/sizeof(int);
-            label = "Tetris";
-            break;
-        case TUNE_HEAT_DONE:
-            notes = heatNotes;
-            durs = heatDur;
-            length = sizeof(heatNotes)/sizeof(int);
-            label = "Heat";
-            break;
-        case TUNE_MARIO:
-        default:
-            break;
+    if (tune == TUNE_HEAT_DONE) {
+        notes = heatNotes;
+        durs = heatDur;
+        length = sizeof(heatNotes)/sizeof(int);
+        label = "Heat";
     }
 
     lcd.clear();

--- a/main/tunes.h
+++ b/main/tunes.h
@@ -1,6 +1,29 @@
 #pragma once
 #include <Arduino.h>
 
+// ----- Tune selection macros -----
+// Define exactly one of the following to select the tune included in firmware.
+// If none is defined, USE_TUNE_MARIO is the default.
+// Defining more than one will trigger a compile-time error.
+
+#if defined(USE_TUNE_MARIO) + defined(USE_TUNE_CANON) + defined(USE_TUNE_STAR_WARS) + defined(USE_TUNE_TETRIS) > 1
+#error "Only one USE_TUNE_* macro may be defined"
+#endif
+
+#if !(defined(USE_TUNE_MARIO) || defined(USE_TUNE_CANON) || defined(USE_TUNE_STAR_WARS) || defined(USE_TUNE_TETRIS))
+#define USE_TUNE_MARIO
+#endif
+
+#if defined(USE_TUNE_MARIO)
+#define DEFAULT_TUNE TUNE_MARIO
+#elif defined(USE_TUNE_CANON)
+#define DEFAULT_TUNE TUNE_CANON
+#elif defined(USE_TUNE_STAR_WARS)
+#define DEFAULT_TUNE TUNE_STAR_WARS
+#elif defined(USE_TUNE_TETRIS)
+#define DEFAULT_TUNE TUNE_TETRIS
+#endif
+
 
 // Enumeration of available completion tunes
 enum TuneType {


### PR DESCRIPTION
## Summary
- support choosing a single tune at compile time
- keep heat-done beep always available
- drop runtime M401 command
- document tune selection macros in README

## Testing
- `g++ -c main/tunes.cpp -I/usr/include -I.` *(fails: Arduino headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_6881ef1bbc448326acdf76dd698d343f