### PR TITLE
Update coordinate screen with relative mode info

### DIFF
--- a/main/gcode.cpp
+++ b/main/gcode.cpp
@@ -256,8 +256,31 @@ void processGcode() {
                     if (!he) te = useRelativeE ? 0 : printer.posE;
                 }
 
+                long distX = useAbsoluteXYZ ? tx - printer.posX : tx;
+                long distY = useAbsoluteXYZ ? ty - printer.posY : ty;
+                long distZ = useAbsoluteXYZ ? tz - printer.posZ : tz;
+                long distE = useRelativeE ? te : (useAbsoluteXYZ ? te - printer.posE : te);
+
+                printer.remStepX = lroundf(fabs(distX * stepsPerMM_X));
+                printer.remStepY = lroundf(fabs(distY * stepsPerMM_Y));
+                printer.remStepZ = lroundf(fabs(distZ * stepsPerMM_Z));
+                printer.remStepE = lroundf(fabs(distE * stepsPerMM_E));
+                printer.signX = (distX >= 0) ? 1 : -1;
+                printer.signY = (distY >= 0) ? 1 : -1;
+                printer.signZ = (distZ >= 0) ? 1 : -1;
+                printer.signE = (distE >= 0) ? 1 : -1;
+
+                printer.nextX = useAbsoluteXYZ ? tx : distX;
+                printer.nextY = useAbsoluteXYZ ? ty : distY;
+                printer.nextZ = useAbsoluteXYZ ? tz : distZ;
+                printer.nextE = useRelativeE ? te : (useAbsoluteXYZ ? te : distE);
+                printer.hasNextMove = true;
+
                 moveAxes(tx, ty, tz, te, currentFeedrate);
 
+                printer.hasNextMove = false;
+                printer.remStepX = printer.remStepY = printer.remStepZ = printer.remStepE = 0;
+                
                 String moveMsg = F("Move");
                 if (hx) { moveMsg += " X"; moveMsg += printer.posX; }
                 if (hy) { moveMsg += " Y"; moveMsg += printer.posY; }

--- a/main/main.ino
+++ b/main/main.ino
@@ -135,8 +135,17 @@ void displayTempScreen() {
 
 void displayCoordScreen() {
     char buf1[17], buf2[17];
-    snprintf(buf1, sizeof(buf1), "X%ld Y%ld", printer.posX, printer.posY);
-    snprintf(buf2, sizeof(buf2), "Z%ld E%ld", printer.posZ, printer.posE);
+    if (useAbsoluteXYZ) {
+        snprintf(buf1, sizeof(buf1), "X%ld Y%ld", printer.posX, printer.posY);
+        snprintf(buf2, sizeof(buf2), "Z%ld E%ld", printer.posZ, printer.posE);
+    } else {
+        long rx = printer.signX * lroundf(printer.remStepX / stepsPerMM_X);
+        long ry = printer.signY * lroundf(printer.remStepY / stepsPerMM_Y);
+        long rz = printer.signZ * lroundf(printer.remStepZ / stepsPerMM_Z);
+        long re = printer.signE * lroundf(printer.remStepE / stepsPerMM_E);
+        snprintf(buf1, sizeof(buf1), "%ld %ld %ld %ld", rx, ry, rz, re);
+        snprintf(buf2, sizeof(buf2), "%ld %ld %ld %ld", printer.nextX, printer.nextY, printer.nextZ, printer.nextE);
+    }
     showMessage(buf1, buf2);
 }
 
@@ -236,14 +245,14 @@ void updateLCD() {
     }
 
     bool moving = (millis() - printer.lastMoveTime) < 1000 && printer.movingAxis != ' ';
-    lcd.setCursor(12, 1);
-    lcd.print(' ');
+    lcd.setCursor(11, 1);
     lcd.print(printer.heaterOn ? 'H' : ' ');
+    lcd.setCursor(12, 1);
+    lcd.print(useAbsoluteXYZ ? "ABS" : "REL");
+    lcd.setCursor(15, 1);
     if (moving) {
-        lcd.print(printer.movingAxis);
         lcd.print(printer.movingDir > 0 ? '>' : '<');
     } else {
-        lcd.print(' ');
         lcd.print(anim[animPos]);
         animPos = (animPos + 1) % 4;
     }

--- a/main/motion.cpp
+++ b/main/motion.cpp
@@ -8,6 +8,8 @@
 // Access button handling from main program
 extern void checkButton();
 extern bool useRelativeE;
+extern int displayMode;
+extern void updateLCD();
 
 
 // Calculate step count and apply extrusion limits
@@ -47,6 +49,7 @@ static void moveWithAccel(int stepPin, long steps, long minDelay) {
         if (now - lastPoll >= 50) {
             lastPoll = now;
             checkButton();
+            if (displayMode == 1) updateLCD();
             wdt_reset();
         }
 
@@ -139,15 +142,16 @@ static void moveWithAccelSync(long stepsX, long stepsY, long stepsZ, long stepsE
         if (doZ) digitalWrite(stepPinZ, HIGH);
         if (doE) digitalWrite(stepPinE, HIGH);
         if (doX || doY || doZ || doE) delayMicroseconds(1000);
-        if (doX) digitalWrite(stepPinX, LOW);
-        if (doY) digitalWrite(stepPinY, LOW);
-        if (doZ) digitalWrite(stepPinZ, LOW);
-        if (doE) digitalWrite(stepPinE, LOW);
+        if (doX) { digitalWrite(stepPinX, LOW); if (printer.remStepX > 0) printer.remStepX--; }
+        if (doY) { digitalWrite(stepPinY, LOW); if (printer.remStepY > 0) printer.remStepY--; }
+        if (doZ) { digitalWrite(stepPinZ, LOW); if (printer.remStepZ > 0) printer.remStepZ--; }
+        if (doE) { digitalWrite(stepPinE, LOW); if (printer.remStepE > 0) printer.remStepE--; }
 
         unsigned long now = millis();
         if (now - lastPoll >= 50) {
             lastPoll = now;
             checkButton();
+            if (displayMode == 1) updateLCD();
             wdt_reset();
         }
 

--- a/main/state.cpp
+++ b/main/state.cpp
@@ -38,6 +38,11 @@ void resetPrinterState() {
     printer.currentTune = DEFAULT_TUNE; // default tune selected in tunes.h
 
     printer.paused = false;
+
+    printer.nextX = printer.nextY = printer.nextZ = printer.nextE = 0;
+    printer.hasNextMove = false;
+    printer.remStepX = printer.remStepY = printer.remStepZ = printer.remStepE = 0;
+    printer.signX = printer.signY = printer.signZ = printer.signE = 1;
 }
 
 void updateProgress() {

--- a/main/state.h
+++ b/main/state.h
@@ -36,6 +36,12 @@ struct PrinterState {
 
     // 暫停狀態 (M0)
     bool paused;
+
+    // Upcoming and remaining move tracking
+    long nextX, nextY, nextZ, nextE; // next target or relative move
+    bool hasNextMove;
+    long remStepX, remStepY, remStepZ, remStepE; // remaining steps during move
+    int signX, signY, signZ, signE; // direction of current move
 };
 
 extern PrinterState printer;


### PR DESCRIPTION
## Summary
- track next movement and remaining steps in `PrinterState`
- set next move details when parsing `G1`
- update LCD during moves and show mode label
- display remaining and next move distances in relative mode

## Testing
- `g++` compilation failed: `Arduino.h` missing
- `apt-get update` failed: `403  Forbidden`

------
https://chatgpt.com/codex/tasks/task_e_68820e35a8208326b02acaf286354044