### PR TITLE
Enable turning off tunes

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,10 +231,10 @@ M400
 
 ### 音樂選擇
 
-預設只會編譯一首完成提示音，可在 `tunes.h` 定義下列其中一個旗標：
+預設不會編譯任何完成提示音，如需音樂可在 `tunes.h` 定義下列其中一個旗標：
 
 ```cpp
-#define USE_TUNE_MARIO      // 預設
+#define USE_TUNE_MARIO
 //#define USE_TUNE_CANON
 //#define USE_TUNE_STAR_WARS
 //#define USE_TUNE_TETRIS

--- a/main/tunes.h
+++ b/main/tunes.h
@@ -2,8 +2,8 @@
 #include <Arduino.h>
 
 // ----- Tune selection macros -----
-// Define exactly one of the following to select the tune included in firmware.
-// If none is defined, USE_TUNE_MARIO is the default.
+// Define at most one of the following to select the tune included in firmware.
+// If none is defined, tunes will be disabled automatically.
 // Defining more than one will trigger a compile-time error.
 
 #if defined(USE_TUNE_MARIO) + defined(USE_TUNE_CANON) + defined(USE_TUNE_STAR_WARS) + defined(USE_TUNE_TETRIS) > 1
@@ -11,7 +11,7 @@
 #endif
 
 #if !(defined(USE_TUNE_MARIO) || defined(USE_TUNE_CANON) || defined(USE_TUNE_STAR_WARS) || defined(USE_TUNE_TETRIS))
-#define USE_TUNE_MARIO
+#define NO_TUNES
 #endif
 
 #if defined(USE_TUNE_MARIO)
@@ -22,6 +22,8 @@
 #define DEFAULT_TUNE TUNE_STAR_WARS
 #elif defined(USE_TUNE_TETRIS)
 #define DEFAULT_TUNE TUNE_TETRIS
+#else
+#define DEFAULT_TUNE TUNE_MARIO
 #endif
 
 


### PR DESCRIPTION
## Summary
- document that tunes are optional
- allow tune macros to be omitted in `tunes.h`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688242fcf0748326bac7b0b71c3f86e7