### PR TITLE
Set idle screen to display immediately

### DIFF
--- a/main/main.ino
+++ b/main/main.ino
@@ -40,7 +40,8 @@ int displayMode = 0;
 unsigned long lastPressTime = 0;
 unsigned long lastDisplaySwitch = 0;
 const unsigned long autoSwitchDelay = 30000;
-const unsigned long idleSwitchDelay = 30000;
+// Immediately show the idle screen after startup
+const unsigned long idleSwitchDelay = 0;
 bool isLongPress = false;
 bool confirmStop = false;
 unsigned long confirmStartTime = 0;


### PR DESCRIPTION
## Summary
- show the idle LCD screen right after startup by setting `idleSwitchDelay` to `0`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68824f2cd6ec83269a79c9b13715aedc