### PR TITLE
Fix simulation flag configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Print speed = 20mm/s
 
 ## 模擬模式
 
-若無需連接切片軟體，可開啟模擬模式執行內建範例。請依需求取消下列 `main.ino` 中的註解：
+若無需連接切片軟體，可開啟模擬模式執行內建範例。請依需求到 `main/config.h` 定義下列旗標：
 
 ```cpp
 #define SIMULATE_GCODE_INPUT   // 自動執行預設 G-code（包含移動與擠出）

--- a/main/config.h
+++ b/main/config.h
@@ -1,0 +1,13 @@
+#pragma once
+
+// Uncomment to feed predefined G-code without host software
+// When enabled the heater output is mocked and test G-code is fed
+// automatically. Motors will move according to the commands unless
+// SIMULATE_EXTRUDER is also defined.
+//#define SIMULATE_GCODE_INPUT
+
+// Uncomment to bypass real heater control and simulate temperature readings
+//#define SIMULATE_HEATER
+
+// Skip real extruder movement when simulating
+//#define SIMULATE_EXTRUDER

--- a/main/gcode.cpp
+++ b/main/gcode.cpp
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <math.h>
+#include "config.h"
 
 // Unified serial response helper
 void sendOk(const String &msg = "") {

--- a/main/main.ino
+++ b/main/main.ino
@@ -1,11 +1,5 @@
-// Uncomment to feed predefined G-code without host software
-// When enabled the heater output is mocked and test G-code is fed
-// automatically. Motors will move according to the commands unless
-// SIMULATE_EXTRUDER is also defined.
-//#define SIMULATE_GCODE_INPUT
-// Uncomment to bypass real heater control and simulate temperature readings
-//#define SIMULATE_HEATER
-//#define SIMULATE_EXTRUDER      // Skip real extruder movement when simulating
+// Simulation flags are defined in config.h
+#include "config.h"
 
 #include <Wire.h>
 #include <LiquidCrystal_I2C.h>

--- a/main/motion.cpp
+++ b/main/motion.cpp
@@ -3,6 +3,7 @@
 #include "state.h"
 #include "gcode.h"
 #include <Arduino.h>
+#include "config.h"
 
 // Access button handling from main program
 extern void checkButton();

--- a/main/temp_control.cpp
+++ b/main/temp_control.cpp
@@ -4,6 +4,7 @@
 #include <math.h>
 #include "state.h"
 #include "tunes.h"
+#include "config.h"
 
 // Uncomment to enable verbose serial logging from readTemperature()
 //#define DEBUG_LOGS


### PR DESCRIPTION
## Summary
- add new `config.h` header for global simulation macros
- include `config.h` in main files
- update documentation about where to enable simulation mode

## Testing
- `g++ -std=c++11 -c main/*.cpp` *(fails: Arduino headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_688256ca4b18832680192b2b462b5937