### PR TITLE
Restrict idle screen to print mode

### DIFF
--- a/main/main.ino
+++ b/main/main.ino
@@ -201,7 +201,9 @@ void updateLCD() {
     static int animPos = 0;
     static const char anim[] = "|/-\\";
 
-    bool idle = (printer.eTotal == -1 && millis() - lastPressTime >= idleSwitchDelay);
+    bool idle = (displayMode == 0 &&
+                 printer.eTotal == -1 &&
+                 millis() - lastPressTime >= idleSwitchDelay);
     if (idle) {
         displayIdleScreen(animPos);
     } else if (displayMode == 0) {


### PR DESCRIPTION
## Summary
- show idle screen only when displayMode is set to progress mode

## Testing
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68825c4144e48326959042829075fcf7