### PR TITLE
Add float coordinate support for G1

### DIFF
--- a/main/gcode.cpp
+++ b/main/gcode.cpp
@@ -94,11 +94,11 @@ void processGcode() {
             useRelativeE = true;
             sendOk(F("M83 E relative"));
         } else if (gcode.startsWith("G92")) {   // G92 - 手動設定目前座標（包含 E 也會同步進度 eStart）
-            if (gcode.indexOf('X') != -1) printer.posX = gcode.substring(gcode.indexOf('X') + 1).toInt();
-            if (gcode.indexOf('Y') != -1) printer.posY = gcode.substring(gcode.indexOf('Y') + 1).toInt();
-            if (gcode.indexOf('Z') != -1) printer.posZ = gcode.substring(gcode.indexOf('Z') + 1).toInt();
+            if (gcode.indexOf('X') != -1) printer.posX = gcode.substring(gcode.indexOf('X') + 1).toFloat();
+            if (gcode.indexOf('Y') != -1) printer.posY = gcode.substring(gcode.indexOf('Y') + 1).toFloat();
+            if (gcode.indexOf('Z') != -1) printer.posZ = gcode.substring(gcode.indexOf('Z') + 1).toFloat();
             if (gcode.indexOf('E') != -1) {
-                printer.posE = gcode.substring(gcode.indexOf('E') + 1).toInt();
+                printer.posE = gcode.substring(gcode.indexOf('E') + 1).toFloat();
                 printer.eStart = printer.posE;  // 同步進度起點，避免重設座標後估算錯誤
                 sendOk(F("G92 E origin reset"));
             } else {
@@ -232,16 +232,16 @@ void processGcode() {
                         currentFeedrate = parsed;
                 }
 
-                auto parseAxis = [&](char a, long &out)->bool {
+                auto parseAxis = [&](char a, float &out)->bool {
                     int idx = gcode.indexOf(a);
                     if (idx == -1) return false;
                     int end = gcode.indexOf(' ', idx);
                     String valStr = (end != -1) ? gcode.substring(idx + 1, end) : gcode.substring(idx + 1);
-                    out = valStr.toInt();
+                    out = valStr.toFloat();
                     return true;
                 };
 
-                long tx = 0, ty = 0, tz = 0, te = 0;
+                float tx = 0, ty = 0, tz = 0, te = 0;
                 bool hx = parseAxis('X', tx);
                 bool hy = parseAxis('Y', ty);
                 bool hz = parseAxis('Z', tz);
@@ -256,15 +256,15 @@ void processGcode() {
                     if (!he) te = useRelativeE ? 0 : printer.posE;
                 }
 
-                long distX = useAbsoluteXYZ ? tx - printer.posX : tx;
-                long distY = useAbsoluteXYZ ? ty - printer.posY : ty;
-                long distZ = useAbsoluteXYZ ? tz - printer.posZ : tz;
-                long distE = useRelativeE ? te : (useAbsoluteXYZ ? te - printer.posE : te);
+                float distX = useAbsoluteXYZ ? tx - printer.posX : tx;
+                float distY = useAbsoluteXYZ ? ty - printer.posY : ty;
+                float distZ = useAbsoluteXYZ ? tz - printer.posZ : tz;
+                float distE = useRelativeE ? te : (useAbsoluteXYZ ? te - printer.posE : te);
 
-                printer.remStepX = lroundf(fabs(distX * stepsPerMM_X));
-                printer.remStepY = lroundf(fabs(distY * stepsPerMM_Y));
-                printer.remStepZ = lroundf(fabs(distZ * stepsPerMM_Z));
-                printer.remStepE = lroundf(fabs(distE * stepsPerMM_E));
+                printer.remStepX = lroundf(fabsf(distX * stepsPerMM_X));
+                printer.remStepY = lroundf(fabsf(distY * stepsPerMM_Y));
+                printer.remStepZ = lroundf(fabsf(distZ * stepsPerMM_Z));
+                printer.remStepE = lroundf(fabsf(distE * stepsPerMM_E));
                 printer.signX = (distX >= 0) ? 1 : -1;
                 printer.signY = (distY >= 0) ? 1 : -1;
                 printer.signZ = (distZ >= 0) ? 1 : -1;
@@ -291,9 +291,9 @@ void processGcode() {
             homeAxis(stepPinX, dirPinX, endstopX, "X");
             homeAxis(stepPinY, dirPinY, endstopY, "Y");
             homeAxis(stepPinZ, dirPinZ, endstopZ, "Z");
-            printer.posX = 0;
-            printer.posY = 0;
-            printer.posZ = 0;
+            printer.posX = 0.0f;
+            printer.posY = 0.0f;
+            printer.posZ = 0.0f;
             sendOk(F("G28 Done"));
         } else {  // 其他未知指令
             Serial.print(F("ERR: Unknown cmd "));

--- a/main/main.ino
+++ b/main/main.ino
@@ -138,15 +138,25 @@ void displayProgressScreen() {
 void displayCoordScreen() {
     char buf1[17], buf2[17];
     if (useAbsoluteXYZ) {
-        snprintf(buf1, sizeof(buf1), "X%ld Y%ld", printer.posX, printer.posY);
-        snprintf(buf2, sizeof(buf2), "Z%ld E%ld", printer.posZ, printer.posE);
+        char xbuf[8], ybuf[8], zbuf[8], ebuf[8];
+        dtostrf(printer.posX, 4, 1, xbuf);
+        dtostrf(printer.posY, 4, 1, ybuf);
+        dtostrf(printer.posZ, 4, 1, zbuf);
+        dtostrf(printer.posE, 4, 1, ebuf);
+        snprintf(buf1, sizeof(buf1), "X%s Y%s", xbuf, ybuf);
+        snprintf(buf2, sizeof(buf2), "Z%s E%s", zbuf, ebuf);
     } else {
         long rx = printer.signX * lroundf(printer.remStepX / stepsPerMM_X);
         long ry = printer.signY * lroundf(printer.remStepY / stepsPerMM_Y);
         long rz = printer.signZ * lroundf(printer.remStepZ / stepsPerMM_Z);
         long re = printer.signE * lroundf(printer.remStepE / stepsPerMM_E);
         snprintf(buf1, sizeof(buf1), "%ld %ld %ld %ld", rx, ry, rz, re);
-        snprintf(buf2, sizeof(buf2), "%ld %ld %ld %ld", printer.nextX, printer.nextY, printer.nextZ, printer.nextE);
+        char nx[8], ny[8], nz[8], ne[8];
+        dtostrf(printer.nextX, 4, 1, nx);
+        dtostrf(printer.nextY, 4, 1, ny);
+        dtostrf(printer.nextZ, 4, 1, nz);
+        dtostrf(printer.nextE, 4, 1, ne);
+        snprintf(buf2, sizeof(buf2), "%s %s %s %s", nx, ny, nz, ne);
     }
     showMessage(buf1, buf2);
 }

--- a/main/motion.cpp
+++ b/main/motion.cpp
@@ -13,7 +13,7 @@ extern void updateLCD();
 
 
 // Calculate step count and apply extrusion limits
-static long calculateSteps(char axis, long currentPos, int &distance, float spm) {
+static long calculateSteps(char axis, float currentPos, float &distance, float spm) {
     if (axis == 'E' && distance > 0) {
         extern int eMaxSteps;
         if (currentPos + distance > eMaxSteps) {
@@ -21,12 +21,12 @@ static long calculateSteps(char axis, long currentPos, int &distance, float spm)
             if (distance <= 0) return 0;
         }
     }
-    return lroundf(fabs(distance * spm));
+    return lroundf(fabsf(distance * spm));
 }
 
 // Set motor direction based on travel distance
-static void setMotorDirection(int dirPin, int distance) {
-    int dir = (distance >= 0) ? HIGH : LOW;
+static void setMotorDirection(int dirPin, float distance) {
+    int dir = (distance >= 0.0f) ? HIGH : LOW;
     digitalWrite(dirPin, dir);
 }
 
@@ -66,8 +66,8 @@ static void moveWithAccel(int stepPin, long steps, long minDelay) {
     }
 }
 
-void moveAxis(int stepPin, int dirPin, long& pos, int target, int feedrate, char axis) {
-    int distance;
+void moveAxis(int stepPin, int dirPin, float& pos, float target, int feedrate, char axis) {
+    float distance;
     if (axis == 'E' && useRelativeE) {
         distance = target;
     } else {
@@ -177,11 +177,11 @@ static void moveWithAccelSync(long stepsX, long stepsY, long stepsZ, long stepsE
     }
 }
 
-void moveAxes(long targetX, long targetY, long targetZ, long targetE, int feedrate) {
-    int distX = useAbsoluteXYZ ? targetX - printer.posX : targetX;
-    int distY = useAbsoluteXYZ ? targetY - printer.posY : targetY;
-    int distZ = useAbsoluteXYZ ? targetZ - printer.posZ : targetZ;
-    int distE;
+void moveAxes(float targetX, float targetY, float targetZ, float targetE, int feedrate) {
+    float distX = useAbsoluteXYZ ? targetX - printer.posX : targetX;
+    float distY = useAbsoluteXYZ ? targetY - printer.posY : targetY;
+    float distZ = useAbsoluteXYZ ? targetZ - printer.posZ : targetZ;
+    float distE;
     if (useRelativeE) {
         distE = targetE;
     } else {
@@ -245,11 +245,11 @@ void moveAxes(long targetX, long targetY, long targetZ, long targetE, int feedra
     updateProgress();
 
     char axis = 'X';
-    int disp = distX;
-    long absDist = labs(distX);
-    if (labs(distY) > absDist) { axis='Y'; absDist=labs(distY); disp = distY; }
-    if (labs(distZ) > absDist) { axis='Z'; absDist=labs(distZ); disp = distZ; }
-    if (labs(distE) > absDist) { axis='E'; absDist=labs(distE); disp = distE; }
+    float disp = distX;
+    float absDist = fabsf(distX);
+    if (fabsf(distY) > absDist) { axis='Y'; absDist=fabsf(distY); disp = distY; }
+    if (fabsf(distZ) > absDist) { axis='Z'; absDist=fabsf(distZ); disp = distZ; }
+    if (fabsf(distE) > absDist) { axis='E'; absDist=fabsf(distE); disp = distE; }
     printer.movingAxis = axis;
     printer.movingDir = (disp >= 0) ? 1 : -1;
     printer.lastMoveTime = millis();

--- a/main/motion.h
+++ b/main/motion.h
@@ -1,8 +1,8 @@
 #pragma once
 #include <Arduino.h>
 
-void moveAxis(int stepPin, int dirPin, long& pos, int target, int feedrate, char axis);
+void moveAxis(int stepPin, int dirPin, float& pos, float target, int feedrate, char axis);
 
 void homeAxis(int stepPin, int dirPin, int endstopPin, const char* label);
 
-void moveAxes(long targetX, long targetY, long targetZ, long targetE, int feedrate);
+void moveAxes(float targetX, float targetY, float targetZ, float targetE, int feedrate);

--- a/main/state.cpp
+++ b/main/state.cpp
@@ -11,10 +11,10 @@ void resetPrinterState() {
     printer.heatDoneBeeped = false;
     printer.waitingForHeat = false;
 
-    printer.posX = printer.posY = printer.posZ = printer.posE = 0;
-    printer.eStart = 0;
+    printer.posX = printer.posY = printer.posZ = printer.posE = 0.0f;
+    printer.eStart = 0.0f;
     // -1 indicates progress total not set
-    printer.eTotal = -1;
+    printer.eTotal = -1.0f;
     printer.progress = 0;
     printer.eStartSynced = false;
 
@@ -37,25 +37,25 @@ void resetPrinterState() {
 
     printer.paused = false;
 
-    printer.nextX = printer.nextY = printer.nextZ = printer.nextE = 0;
+    printer.nextX = printer.nextY = printer.nextZ = printer.nextE = 0.0f;
     printer.hasNextMove = false;
     printer.remStepX = printer.remStepY = printer.remStepZ = printer.remStepE = 0;
     printer.signX = printer.signY = printer.signZ = printer.signE = 1;
 }
 
 void updateProgress() {
-    if (printer.eTotal > 0) {
+    if (printer.eTotal > 0.0f) {
         if (printer.eStart > printer.posE) {
             // Avoid negative delta when retracting
             printer.eStart = printer.posE;
         }
-        long delta = printer.posE - printer.eStart;
+        float delta = printer.posE - printer.eStart;
         if (delta >= printer.eTotal) {
             printer.progress = 100;
             // Mark print as complete until user confirms
-            printer.eTotal = 0;
-        } else if (delta > 0) {
-            printer.progress = (int)(delta * 100L / printer.eTotal);
+            printer.eTotal = 0.0f;
+        } else if (delta > 0.0f) {
+            printer.progress = (int)(delta * 100.0f / printer.eTotal);
         }
     }
 }

--- a/main/state.h
+++ b/main/state.h
@@ -11,8 +11,8 @@ struct PrinterState {
     float lastOutput;
 
     // 馬達與進度
-    long posX, posY, posZ, posE;
-    long eStart, eTotal;
+    float posX, posY, posZ, posE;
+    float eStart, eTotal;
     int progress;
     bool eStartSynced;
 
@@ -36,7 +36,7 @@ struct PrinterState {
     bool paused;
 
     // Upcoming and remaining move tracking
-    long nextX, nextY, nextZ, nextE; // next target or relative move
+    float nextX, nextY, nextZ, nextE; // next target or relative move
     bool hasNextMove;
     long remStepX, remStepY, remStepZ, remStepE; // remaining steps during move
     int signX, signY, signZ, signE; // direction of current move


### PR DESCRIPTION
## Summary
- allow fractional G-code coordinates by storing positions as `float`
- parse `G92` coordinates as float
- compute movement distances and step counts using floats
- update LCD output to show one decimal precision

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6882e3cdf3508326b0ad3ca24ce24ead