### PR TITLE
Clean up removed features

### DIFF
--- a/main/button.cpp
+++ b/main/button.cpp
@@ -51,21 +51,3 @@ bool longPressed(unsigned long ms) {
     return isPressed() && (millis() - pressStart >= ms);
 }
 
-bool doublePressed(unsigned long ms) {
-    static unsigned long lastSingle = 0;
-    static const unsigned long debounceGap = 50; // ignore presses too close together
-    if (consumeJust()) {
-        unsigned long now = millis();
-        if (now - lastSingle <= debounceGap) {
-            // treat as bounce
-            lastSingle = now;
-            return false;
-        }
-        if (now - lastSingle <= ms) {
-            lastSingle = 0;
-            return true;
-        }
-        lastSingle = now;
-    }
-    return false;
-}

--- a/main/button.h
+++ b/main/button.h
@@ -5,4 +5,3 @@ void updateButton();
 bool isPressed();
 bool justPressed();
 bool longPressed(unsigned long ms);
-bool doublePressed(unsigned long ms);

--- a/main/gcode.cpp
+++ b/main/gcode.cpp
@@ -21,7 +21,6 @@ void sendOk(const String &msg = "") {
 // 外部變數宣告
 extern bool useAbsoluteXYZ;
 extern bool useRelativeE;
-extern bool useRelativeE;
 extern int currentFeedrate;
 extern const int stepPinX, dirPinX, stepPinY, dirPinY, stepPinZ, dirPinZ, stepPinE, dirPinE;
 extern const int endstopX, endstopY, endstopZ;
@@ -45,7 +44,6 @@ static const char *debugCommands[] = {
     "G1 E100 F600",
     "M105",
     "M400",
-    // "M401 S1" // tune selection removed
 };
 static const int debugCommandCount = sizeof(debugCommands) / sizeof(debugCommands[0]);
 static int debugIndex = 0;
@@ -166,7 +164,7 @@ void processGcode() {
             sendOk(pidMsg);
         } else if (gcode.startsWith("M400")) {  // M400 - 播放選定音樂，列印完成提示
 #ifndef NO_TUNES
-            playTune(printer.currentTune);
+            playTune(DEFAULT_TUNE);
 #endif
             sendOk(F("Print Complete"));
         } else if (gcode.startsWith("M92")) {   // M92 - 設定各軸 steps/mm

--- a/main/main.ino
+++ b/main/main.ino
@@ -301,15 +301,6 @@ void autoSwitchDisplay() {
     }
 }
 
-void forceStop() {
-    printer.setTemp = 0;
-    analogWrite(heaterPin, 0);
-    printer.heaterOn = false;
-    displayFrozen = true;
-    freezeStartTime = millis();
-    showMessage("** Forced STOP **", "");
-}
-
 void enterPauseMode() {
     printer.paused = true;
     showMessage("** Paused **", "Press Button");

--- a/main/state.cpp
+++ b/main/state.cpp
@@ -33,7 +33,6 @@ void resetPrinterState() {
     printer.previousError = 0.0f;
     printer.lastTime = millis();
 
-    printer.currentTune = DEFAULT_TUNE; // default tune selected in tunes.h
 
     printer.paused = false;
 

--- a/main/state.h
+++ b/main/state.h
@@ -29,9 +29,6 @@ struct PrinterState {
     float integral, previousError;
     unsigned long lastTime;
 
-    // 音樂
-    int currentTune;
-
     // 暫停狀態 (M0)
     bool paused;
 


### PR DESCRIPTION
## Summary
- drop unused `doublePressed` helper
- simplify test G-code list in `gcode.cpp`
- always play the default tune
- remove obsolete `currentTune` state field
- drop unused `forceStop()` helper

## Testing
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68831d19bc0c8326b09472f762234336