### PR TITLE
Add fallback beep for NO_TUNES mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ M400
 
 若不需要蜂鳴器音樂功能，可在編譯時定義 `NO_TUNES` 旗標，
 系統將排除音樂資料與 `playTune()` 的實作，相關呼叫也會被忽略。
+在此模式下，可利用 `simpleBeep(pin, freq, duration_ms)` 播放短促蜂鳴聲作為提醒。
 
 ## Debug 日誌
 

--- a/main/gcode.cpp
+++ b/main/gcode.cpp
@@ -287,6 +287,8 @@ void processGcode() {
         } else if (gcode.startsWith("M400")) {  // M400 - 播放選定音樂，列印完成提示
 #ifndef NO_TUNES
             playTune(DEFAULT_TUNE);
+#else
+            simpleBeep(buzzerPin, 1000, 200);
 #endif
             sendOk(F("Print Complete"));
         } else if (gcode.startsWith("M92")) {   // M92 - 設定各軸 steps/mm

--- a/main/temp_control.cpp
+++ b/main/temp_control.cpp
@@ -181,6 +181,8 @@ void controlHeater() {
             if (!printer.heatDoneBeeped && (now - heatStableStart >= stableHoldTime)) {
 #ifndef NO_TUNES
                 playTune(TUNE_HEAT_DONE);
+#else
+                simpleBeep(buzzerPin, 1000, 200);
 #endif
                 printer.heatDoneBeeped = true;
             }

--- a/main/tunes.cpp
+++ b/main/tunes.cpp
@@ -55,3 +55,17 @@ void playTune(int tune) {
     delay(500);
 }
 #endif // NO_TUNES
+
+// Simple one-shot beep for alerts when tunes are disabled
+void simpleBeep(int pin, int freq, int duration_ms) {
+    long period_us = 1000000L / freq;
+    long halfPeriod = period_us / 2;
+    long cycles = (long)duration_ms * 1000L / period_us;
+
+    for (long i = 0; i < cycles; i++) {
+        digitalWrite(pin, HIGH);
+        delayMicroseconds(halfPeriod);
+        digitalWrite(pin, LOW);
+        delayMicroseconds(halfPeriod);
+    }
+}

--- a/main/tunes.h
+++ b/main/tunes.h
@@ -47,3 +47,6 @@ void playTune(int tune);
 #else
 inline void playTune(int) {}
 #endif
+
+// Short beep helper used when tunes are disabled
+void simpleBeep(int pin, int freq, int duration_ms);


### PR DESCRIPTION
## Summary
- clarify README on using `simpleBeep`
- use `simpleBeep` when music tunes are disabled
- document short beep helper in headers

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6883392f92bc83269383d3a4977fd394