### PR TITLE
Reduce flash by removing formatted strings

### DIFF
--- a/main/gcode.h
+++ b/main/gcode.h
@@ -5,7 +5,9 @@
 #include <Arduino.h>
 
 void processGcode();
-void sendOk(const String &msg = "");
+void sendOk(const __FlashStringHelper* msg = nullptr);
+void sendOk(const char* msg);
+void sendOk();
 void enterPauseMode();
 #include "motion.h"
 

--- a/main/motion.cpp
+++ b/main/motion.cpp
@@ -119,8 +119,7 @@ void homeAxis(int stepPin, int dirPin, int endstopPin, const char* label) {
         delayMicroseconds(1000);
     }
     digitalWrite(motorEnablePin, HIGH);
-    extern void sendOk(const String &msg); // from gcode.cpp
-    sendOk(String(label) + " Homed");
+    Serial.print(F("ok ")); Serial.print(label); Serial.println(F(" Homed"));
 }
 
 // Accelerated multi-axis movement using Bresenham/DDA


### PR DESCRIPTION
## Summary
- drop use of `snprintf` and `dtostrf`
- avoid `String` objects in output paths
- print values directly to LCD or Serial

## Testing
- `grep -R snprintf -n`
- `grep -R dtostrf -n`

------
https://chatgpt.com/codex/tasks/task_e_688b07d6ac8c8326ac1187edfa88490a