### PR TITLE
Add portfolio page with anchor offset and labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <title>3D Printer Firmware Portfolio</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="site-header">
+    <nav>
+      <a href="#portfolio">Portfolio</a>
+    </nav>
+  </header>
+  <main>
+    <section id="portfolio" class="anchor-target">
+      <h2>Portfolio</h2>
+      <div class="portfolio-grid">
+        <a class="portfolio-item" href="#">
+          <img src="diagram.jpg" alt="System Diagram" />
+          <span class="label">System Diagram</span>
+        </a>
+        <a class="portfolio-item" href="#">
+          <img src="arduino cnc schedule pinout.jpg" alt="Arduino Pinout" />
+          <span class="label">Arduino Pinout</span>
+        </a>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,52 @@
+:root {
+  --header-height: 60px;
+}
+html,
+body {
+  margin: 0;
+  padding-top: env(safe-area-inset-top);
+}
+.site-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: var(--header-height);
+  background: #333;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  padding: 0 1rem;
+  z-index: 1000;
+}
+main {
+  margin-top: var(--header-height);
+}
+.anchor-target {
+  scroll-margin-top: calc(var(--header-height) + env(safe-area-inset-top));
+}
+.portfolio-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1rem;
+  padding: 1rem;
+}
+.portfolio-item {
+  position: relative;
+  display: block;
+}
+.portfolio-item img {
+  width: 100%;
+  display: block;
+}
+.portfolio-item .label {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  padding: 0.5rem;
+  text-align: center;
+  font-size: 1rem;
+}


### PR DESCRIPTION
## Summary
- Add basic index.html with fixed header and labeled portfolio items
- Include styles.css to reserve safe-area padding and set scroll-margin-top for hash anchors

## Testing
- `npm test` *(fails: Could not read package.json)*
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_6894967c2fa08326b0bb494046c76b09